### PR TITLE
Scaling icons

### DIFF
--- a/DriverInterface.pro
+++ b/DriverInterface.pro
@@ -16,6 +16,7 @@ SOURCES += \
     lights.cpp \
     main.cpp \
     mainwindow.cpp \
+    scaler.cpp \
     speed.cpp \
     warnings.cpp \
     background.cpp \
@@ -29,6 +30,7 @@ HEADERS += \
     indicators.h \
     lights.h \
     mainwindow.h \
+    scaler.h \
     speed.h \
     states.h \
     warnings.h \

--- a/battery.cpp
+++ b/battery.cpp
@@ -1,4 +1,5 @@
 #include "battery.h"
+#include "scaler.h"
 
 Battery::Battery() : battery(100){ return; }
 
@@ -7,6 +8,14 @@ void Battery::setup(Ui::MainWindow *ui) {
   this->ui->battery->setValue(battery);
   range = battery*efficiencyConstant;
   ui->range->display(int(range));
+  int rangeSize = screenWidth*.05;
+
+  ui->rangeLabel->resize(rangeSize, rangeSize);
+  ui->rangeLabel->move(screenWidth/5, screenHeight/4);
+  ui->range->resize(screenWidth/6,rangeSize*1.2);
+  ui->range->move(screenWidth/5, screenHeight/4);
+  ui->battery->resize(screenWidth/4, screenHeight*.05);
+  ui->battery->move(screenWidth/5,screenHeight*.35);
 }
 
 void Battery::increase_battery(int val) {

--- a/cruise.cpp
+++ b/cruise.cpp
@@ -1,10 +1,11 @@
 #include "cruise.h"
+#include "scaler.h"
 
 CruiseControl::CruiseControl() : cruise(OFF) {return;}
 
 void CruiseControl::setup(Ui::MainWindow *ui) {
   this->ui = ui;
-  cruiseControlIcon = QPixmap(":/icons/cruise.png");
+  cruiseControlIcon = QPixmap(":/icons/cruise.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   this->ui->cruiseControlSignal->setText("OFF");
 }
 

--- a/cruise.cpp
+++ b/cruise.cpp
@@ -5,7 +5,9 @@ CruiseControl::CruiseControl() : cruise(OFF) {return;}
 
 void CruiseControl::setup(Ui::MainWindow *ui) {
   this->ui = ui;
+  int topIconWH = .07 * screenWidth;
   cruiseControlIcon = QPixmap(":/icons/cruise.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  ui->cruiseControlSignal->move(4 * screenWidth/6 + hOff,vOff+5);
   this->ui->cruiseControlSignal->setText("OFF");
 }
 

--- a/distance.cpp
+++ b/distance.cpp
@@ -1,4 +1,5 @@
 #include "distance.h"
+#include "scaler.h"
 
 Distance::Distance() : distance(0)
 {
@@ -8,6 +9,12 @@ Distance::Distance() : distance(0)
 void Distance::setup(Ui::MainWindow* ui) {
     this->ui = ui;
     ui->distance->display(distance);
+    int distanceSize = screenWidth*.05;
+
+    ui->distanceLabel->resize(distanceSize, distanceSize);
+    ui->distanceLabel->move(screenWidth/5, screenHeight*.45);
+    ui->distance->resize(screenWidth/6,distanceSize*1.2);
+    ui->distance->move(screenWidth/5, screenHeight*.45);
 }
 
 void Distance::decrease_distance(int value) {

--- a/gears.cpp
+++ b/gears.cpp
@@ -1,13 +1,19 @@
 #include "gears.h"
+#include "scaler.h"
 
 Gears::Gears() : gear(PARK) {return;}
 
 void Gears::setup(Ui::MainWindow *ui) {
   this->ui = ui;
-  parkingIcon = QPixmap(":/icons/parking.png");
-  drivingIcon = QPixmap(":/icons/drive.png");
-  neutralIcon = QPixmap(":/icons/neutral.png");
-  reversingIcon = QPixmap(":/icons/reverse.png");
+  parkingIcon = QPixmap(":/icons/parking.png").scaled(driveModeIconWH,driveModeIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  drivingIcon = QPixmap(":/icons/drive.png").scaled(driveModeIconWH,driveModeIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  neutralIcon = QPixmap(":/icons/neutral.png").scaled(driveModeIconWH,driveModeIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  reversingIcon = QPixmap(":/icons/reverse.png").scaled(driveModeIconWH,driveModeIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+  ui->parkingSignal->move(screenWidth/2- driveModeIconWH - driveModeIconWH,screenHeight-driveModeIconWH);
+  ui->drivingSignal->move(screenWidth/2- driveModeIconWH,screenHeight-driveModeIconWH);
+  ui->neutralSignal->move(screenWidth/2,screenHeight-driveModeIconWH);
+  ui->reversingSignal->move(screenWidth/2 +  driveModeIconWH,screenHeight-driveModeIconWH);
 
   this->ui->parkingSignal->setPixmap(parkingIcon);
   this->ui->drivingSignal->setText("OFF");

--- a/gears.cpp
+++ b/gears.cpp
@@ -5,15 +5,16 @@ Gears::Gears() : gear(PARK) {return;}
 
 void Gears::setup(Ui::MainWindow *ui) {
   this->ui = ui;
+  int driveModeIconWH = .09 * screenHeight;
   parkingIcon = QPixmap(":/icons/parking.png").scaled(driveModeIconWH,driveModeIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   drivingIcon = QPixmap(":/icons/drive.png").scaled(driveModeIconWH,driveModeIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   neutralIcon = QPixmap(":/icons/neutral.png").scaled(driveModeIconWH,driveModeIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   reversingIcon = QPixmap(":/icons/reverse.png").scaled(driveModeIconWH,driveModeIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 
-  ui->parkingSignal->move(screenWidth/2- driveModeIconWH - driveModeIconWH,screenHeight-driveModeIconWH);
-  ui->drivingSignal->move(screenWidth/2- driveModeIconWH,screenHeight-driveModeIconWH);
-  ui->neutralSignal->move(screenWidth/2,screenHeight-driveModeIconWH);
-  ui->reversingSignal->move(screenWidth/2 +  driveModeIconWH,screenHeight-driveModeIconWH);
+  ui->parkingSignal->move(screenWidth/2 - driveModeIconWH*2,screenHeight-driveModeIconWH-vBottomOff-5);
+  ui->drivingSignal->move(screenWidth/2 - driveModeIconWH*1,screenHeight-driveModeIconWH-vBottomOff-5);
+  ui->neutralSignal->move(screenWidth/2 - driveModeIconWH*0,screenHeight-driveModeIconWH-vBottomOff);
+  ui->reversingSignal->move(screenWidth/2 - driveModeIconWH*(-1),screenHeight-driveModeIconWH-vBottomOff);
 
   this->ui->parkingSignal->setPixmap(parkingIcon);
   this->ui->drivingSignal->setText("OFF");

--- a/horn.cpp
+++ b/horn.cpp
@@ -6,7 +6,9 @@ Horn::Horn() : horn(OFF) {return;}
 
 void Horn::setup(Ui::MainWindow *ui) {
   this->ui = ui;
+  int topIconWH = .07 * screenWidth;
   hornSignal = QPixmap(":/icons/horn.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  ui->hornSignal->move(5*screenWidth/6+hOff,vOff+5);
   this->ui->hornSignal->setText("OFF");
 }
 

--- a/horn.cpp
+++ b/horn.cpp
@@ -1,11 +1,12 @@
 #include "horn.h"
+#include "scaler.h"
 
 Horn::Horn() : horn(OFF) {return;}
 
 
 void Horn::setup(Ui::MainWindow *ui) {
   this->ui = ui;
-  hornSignal = QPixmap(":/icons/horn.png");
+  hornSignal = QPixmap(":/icons/horn.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   this->ui->hornSignal->setText("OFF");
 }
 

--- a/indicators.cpp
+++ b/indicators.cpp
@@ -1,4 +1,5 @@
 #include "indicators.h"
+#include "scaler.h"
 #include <QMainWindow>
 
 Indicators::Indicators() : right(OFF), left(OFF) { return; }
@@ -7,8 +8,10 @@ void Indicators::setup(Ui::MainWindow *ui) {
   this->ui = ui;
   this->ui->leftIndicator->setText("OFF");
   this->ui->rightIndicator->setText("OFF");
-  leftSignal = QPixmap(":/icons/left.png");
-  rightSignal = QPixmap(":/icons/right.png");
+  leftSignal = QPixmap(":/icons/left.png").scaled(blinkerIconWH,blinkerIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  rightSignal = QPixmap(":/icons/right.png").scaled(blinkerIconWH,blinkerIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  ui->leftIndicator->move(0,screenHeight/2 - blinkerIconWH/2);
+  ui->rightIndicator->move(screenWidth - blinkerIconWH,screenHeight/2 - blinkerIconWH/2);
 }
 
 void Indicators::left_on() {

--- a/indicators.cpp
+++ b/indicators.cpp
@@ -8,8 +8,9 @@ void Indicators::setup(Ui::MainWindow *ui) {
   this->ui = ui;
   this->ui->leftIndicator->setText("OFF");
   this->ui->rightIndicator->setText("OFF");
-  leftSignal = QPixmap(":/icons/left.png").scaled(blinkerIconWH,blinkerIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
-  rightSignal = QPixmap(":/icons/right.png").scaled(blinkerIconWH,blinkerIconWH+1, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  int blinkerIconWH = .13 * screenWidth;
+  leftSignal = QPixmap(":/icons/left.png").scaled(blinkerIconWH,blinkerIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  rightSignal = QPixmap(":/icons/right.png").scaled(blinkerIconWH,blinkerIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   ui->leftIndicator->move(0,screenHeight/2 - blinkerIconWH/2);
   ui->rightIndicator->move(screenWidth - blinkerIconWH,screenHeight/2 - blinkerIconWH/2);
 }

--- a/lights.cpp
+++ b/lights.cpp
@@ -1,4 +1,5 @@
 #include "lights.h"
+#include "scaler.h"
 
 Lights::Lights() : day(OFF), night(OFF) { return; }
 
@@ -6,8 +7,8 @@ void Lights::setup(Ui::MainWindow *ui) {
   this->ui = ui;
   ui->nightLights->setText("OFF");
   ui->dayLights->setText("OFF");
-  dayLights = QPixmap(":/icons/day.png");
-  nightLights = QPixmap(":/icons/night.png");
+  dayLights = QPixmap(":/icons/day.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  nightLights = QPixmap(":/icons/night.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
 }
 
 void Lights::day_on() {

--- a/lights.cpp
+++ b/lights.cpp
@@ -7,8 +7,11 @@ void Lights::setup(Ui::MainWindow *ui) {
   this->ui = ui;
   ui->nightLights->setText("OFF");
   ui->dayLights->setText("OFF");
+  int topIconWH = .07 * screenWidth;
   dayLights = QPixmap(":/icons/day.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
   nightLights = QPixmap(":/icons/night.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+  ui->dayLights->move(2*screenWidth/6 + hOff,vOff+5);
+  ui->nightLights->move(3*screenWidth/6 + hOff,vOff+1);
 }
 
 void Lights::day_on() {

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -105,139 +105,6 @@ background-color:  #2dcc6b;
      <string>OFF</string>
     </property>
    </widget>
-   <widget class="QWidget" name="horizontalLayoutWidget">
-    <property name="geometry">
-     <rect>
-      <x>10</x>
-      <y>10</y>
-      <width>781</width>
-      <height>80</height>
-     </rect>
-    </property>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
-     </property>
-     <item>
-      <widget class="QLabel" name="batteryWarning">
-       <property name="text">
-        <string>batteryWarning</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="motorWarning">
-       <property name="text">
-        <string>motorWarning</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="dayLights">
-       <property name="text">
-        <string>dayLights</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="nightLights">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>nightLights</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="cruiseControlSignal">
-       <property name="text">
-        <string>cruiseControlSignal</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="hornSignal">
-       <property name="text">
-        <string>hornSignal</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
-   <widget class="QWidget" name="horizontalLayoutWidget_1">
-    <property name="geometry">
-     <rect>
-      <x>80</x>
-      <y>530</y>
-      <width>500</width>
-      <height>80</height>
-     </rect>
-    </property>
-    <layout class="QHBoxLayout" name="horizontalLayout_1">
-     <item>
-      <widget class="QLabel" name="parkingSignal">
-       <property name="text">
-        <string>parkingSignal</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="drivingSignal">
-       <property name="text">
-        <string>drivingSignalSignal</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="neutralSignal">
-       <property name="text">
-        <string>neutralSignal</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="reversingSignal">
-       <property name="text">
-        <string>reversingSignal</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
    <widget class="QWidget" name="gridLayoutWidget">
     <property name="geometry">
      <rect>
@@ -543,8 +410,8 @@ background-color:  #2dcc6b;
      <rect>
       <x>520</x>
       <y>440</y>
-      <width>101</width>
-      <height>80</height>
+      <width>394</width>
+      <height>91</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -668,6 +535,198 @@ background-color:  #2dcc6b;
      <set>Qt::AlignCenter</set>
     </property>
    </widget>
+   <widget class="QLabel" name="parkingSignal">
+    <property name="geometry">
+     <rect>
+      <x>90</x>
+      <y>520</y>
+      <width>119</width>
+      <height>78</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>parkingSignal</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="drivingSignal">
+    <property name="geometry">
+     <rect>
+      <x>470</x>
+      <y>540</y>
+      <width>151</width>
+      <height>71</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>drivingSignalSignal</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="neutralSignal">
+    <property name="geometry">
+     <rect>
+      <x>200</x>
+      <y>540</y>
+      <width>151</width>
+      <height>61</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>neutralSignal</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="reversingSignal">
+    <property name="geometry">
+     <rect>
+      <x>320</x>
+      <y>547</y>
+      <width>171</width>
+      <height>61</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>reversingSignal</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="batteryWarning">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>0</y>
+      <width>123</width>
+      <height>78</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>batteryWarning</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="motorWarning">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>149</width>
+      <height>78</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>motorWarning</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="nightLights">
+    <property name="geometry">
+     <rect>
+      <x>200</x>
+      <y>0</y>
+      <width>188</width>
+      <height>78</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="text">
+     <string>nightLights</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="dayLights">
+    <property name="geometry">
+     <rect>
+      <x>280</x>
+      <y>-10</y>
+      <width>171</width>
+      <height>71</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>dayLights</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="cruiseControlSignal">
+    <property name="geometry">
+     <rect>
+      <x>410</x>
+      <y>0</y>
+      <width>191</width>
+      <height>61</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>cruiseControlSignal</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="hornSignal">
+    <property name="geometry">
+     <rect>
+      <x>600</x>
+      <y>0</y>
+      <width>221</width>
+      <height>61</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>hornSignal</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="TOP_RIGHT_DELETE_ME">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>10</width>
+      <height>10</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>PushButton</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="BOTTOM_RIGHT_DELETE_ME_2">
+    <property name="geometry">
+     <rect>
+      <x>853</x>
+      <y>723</y>
+      <width>10</width>
+      <height>10</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>PushButton</string>
+    </property>
+   </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
@@ -675,7 +734,7 @@ background-color:  #2dcc6b;
      <x>0</x>
      <y>0</y>
      <width>863</width>
-     <height>22</height>
+     <height>37</height>
     </rect>
    </property>
   </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>863</width>
+    <width>1320</width>
     <height>738</height>
    </rect>
   </property>
@@ -26,7 +26,7 @@
     <property name="styleSheet">
      <string notr="true">QProgressBar {
 background: black;
- 	border: 2px solid #2dcc6b;
+        border: 2px solid #2dcc6b;
 }
 
 QProgressBar::chunk {
@@ -44,7 +44,7 @@ background-color:  #2dcc6b;
     <property name="geometry">
      <rect>
       <x>160</x>
-      <y>440</y>
+      <y>330</y>
       <width>100</width>
       <height>32</height>
      </rect>
@@ -56,8 +56,8 @@ background-color:  #2dcc6b;
    <widget class="QPushButton" name="decreaseBattery">
     <property name="geometry">
      <rect>
-      <x>290</x>
-      <y>460</y>
+      <x>280</x>
+      <y>330</y>
       <width>100</width>
       <height>32</height>
      </rect>
@@ -105,12 +105,155 @@ background-color:  #2dcc6b;
      <string>OFF</string>
     </property>
    </widget>
-   <widget class="QWidget" name="gridLayoutWidget">
+   <widget class="QWidget" name="horizontalLayoutWidget">
     <property name="geometry">
      <rect>
       <x>10</x>
-      <y>90</y>
+      <y>10</y>
       <width>781</width>
+      <height>80</height>
+     </rect>
+    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item>
+      <widget class="QLabel" name="battery_label">
+       <property name="text">
+        <string>batteryWarning</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="motor_label">
+       <property name="text">
+        <string>motorWarning</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="low_battery_label">
+       <property name="text">
+        <string>lowBatteryWarning</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="day_lights">
+       <property name="text">
+        <string>dayLights</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="night_lights">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>nightLights</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="cruise_control">
+       <property name="text">
+        <string>cruiseControlSignal</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="horn_label">
+       <property name="text">
+        <string>hornSignal</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+   <widget class="QWidget" name="horizontalLayoutWidget_1">
+    <property name="geometry">
+     <rect>
+      <x>80</x>
+      <y>530</y>
+      <width>500</width>
+      <height>80</height>
+     </rect>
+    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_1">
+     <item>
+      <widget class="QLabel" name="park_label">
+       <property name="text">
+        <string>parkingSignal</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="drive_label">
+       <property name="text">
+        <string>drivingSignalSignal</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="neutral_label">
+       <property name="text">
+        <string>neutralSignal</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="reverse_label">
+       <property name="text">
+        <string>reversingSignal</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+   <widget class="QWidget" name="gridLayoutWidget">
+    <property name="geometry">
+     <rect>
+      <x>115</x>
+      <y>90</y>
+      <width>690</width>
       <height>90</height>
      </rect>
     </property>
@@ -295,7 +438,7 @@ background-color:  #2dcc6b;
      </item>
     </layout>
    </widget>
-   <widget class="QWidget" name="layoutWidget">
+   <widget class="QWidget" name="layoutWidget_1">
     <property name="geometry">
      <rect>
       <x>650</x>
@@ -343,7 +486,7 @@ background-color:  #2dcc6b;
      <set>Qt::AlignCenter</set>
     </property>
    </widget>
-   <widget class="QLabel" name="leftIndicator">
+   <widget class="QLabel" name="left_indicator">
     <property name="geometry">
      <rect>
       <x>0</x>
@@ -389,7 +532,7 @@ background-color:  #2dcc6b;
      <number>125</number>
     </property>
    </widget>
-   <widget class="QLabel" name="rightIndicator">
+   <widget class="QLabel" name="right_indicator">
     <property name="geometry">
      <rect>
       <x>690</x>
@@ -410,8 +553,8 @@ background-color:  #2dcc6b;
      <rect>
       <x>520</x>
       <y>440</y>
-      <width>394</width>
-      <height>91</height>
+      <width>101</width>
+      <height>80</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -491,7 +634,7 @@ background-color:  #2dcc6b;
      <number>125</number>
     </property>
    </widget>
-   <widget class="QLabel" name="rangeLabel">
+   <widget class="QLabel" name="range_label">
     <property name="geometry">
      <rect>
       <x>160</x>
@@ -513,7 +656,7 @@ background-color:  #2dcc6b;
      <set>Qt::AlignCenter</set>
     </property>
    </widget>
-   <widget class="QLabel" name="distanceLabel">
+   <widget class="QLabel" name="distance_label">
     <property name="geometry">
      <rect>
       <x>160</x>
@@ -535,197 +678,203 @@ background-color:  #2dcc6b;
      <set>Qt::AlignCenter</set>
     </property>
    </widget>
-   <widget class="QLabel" name="parkingSignal">
+   <widget class="QWidget" name="verticalLayoutWidget">
     <property name="geometry">
      <rect>
-      <x>90</x>
-      <y>520</y>
-      <width>119</width>
-      <height>78</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>parkingSignal</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QLabel" name="drivingSignal">
-    <property name="geometry">
-     <rect>
-      <x>470</x>
-      <y>540</y>
-      <width>151</width>
+      <x>920</x>
+      <y>80</y>
+      <width>131</width>
       <height>71</height>
      </rect>
     </property>
-    <property name="text">
-     <string>drivingSignalSignal</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_9">
+     <item>
+      <widget class="QPushButton" name="frontLeftON">
+       <property name="text">
+        <string>ON</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="frontLeftOFF">
+       <property name="text">
+        <string>OFF</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </widget>
-   <widget class="QLabel" name="neutralSignal">
+   <widget class="QWidget" name="verticalLayoutWidget_2">
     <property name="geometry">
      <rect>
-      <x>200</x>
-      <y>540</y>
-      <width>151</width>
-      <height>61</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>neutralSignal</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QLabel" name="reversingSignal">
-    <property name="geometry">
-     <rect>
-      <x>320</x>
-      <y>547</y>
-      <width>171</width>
-      <height>61</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>reversingSignal</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QLabel" name="batteryWarning">
-    <property name="geometry">
-     <rect>
-      <x>100</x>
-      <y>0</y>
-      <width>123</width>
-      <height>78</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>batteryWarning</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QLabel" name="motorWarning">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>0</y>
-      <width>149</width>
-      <height>78</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>motorWarning</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QLabel" name="nightLights">
-    <property name="geometry">
-     <rect>
-      <x>200</x>
-      <y>0</y>
-      <width>188</width>
-      <height>78</height>
-     </rect>
-    </property>
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <property name="text">
-     <string>nightLights</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QLabel" name="dayLights">
-    <property name="geometry">
-     <rect>
-      <x>280</x>
-      <y>-10</y>
-      <width>171</width>
+      <x>1100</x>
+      <y>80</y>
+      <width>131</width>
       <height>71</height>
      </rect>
     </property>
-    <property name="text">
-     <string>dayLights</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_10">
+     <item>
+      <widget class="QPushButton" name="frontRightON">
+       <property name="text">
+        <string>ON</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="frontRightOFF">
+       <property name="text">
+        <string>OFF</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </widget>
-   <widget class="QLabel" name="cruiseControlSignal">
+   <widget class="QWidget" name="verticalLayoutWidget_3">
     <property name="geometry">
      <rect>
-      <x>410</x>
-      <y>0</y>
-      <width>191</width>
-      <height>61</height>
+      <x>920</x>
+      <y>390</y>
+      <width>131</width>
+      <height>71</height>
      </rect>
     </property>
-    <property name="text">
-     <string>cruiseControlSignal</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_11">
+     <item>
+      <widget class="QPushButton" name="backLeftON">
+       <property name="text">
+        <string>ON</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="backLeftOFF">
+       <property name="text">
+        <string>OFF</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </widget>
-   <widget class="QLabel" name="hornSignal">
+   <widget class="QWidget" name="verticalLayoutWidget_4">
     <property name="geometry">
      <rect>
-      <x>600</x>
-      <y>0</y>
-      <width>221</width>
-      <height>61</height>
+      <x>1100</x>
+      <y>390</y>
+      <width>131</width>
+      <height>71</height>
      </rect>
     </property>
-    <property name="text">
-     <string>hornSignal</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignCenter</set>
-    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_12">
+     <item>
+      <widget class="QPushButton" name="backRightON">
+       <property name="text">
+        <string>ON</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="backRightOFF">
+       <property name="text">
+        <string>OFF</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </widget>
-   <widget class="QPushButton" name="TOP_RIGHT_DELETE_ME">
+   <widget class="QWidget" name="horizontalLayoutWidget_2">
     <property name="geometry">
      <rect>
-      <x>0</x>
-      <y>0</y>
-      <width>10</width>
-      <height>10</height>
+      <x>940</x>
+      <y>160</y>
+      <width>271</width>
+      <height>221</height>
      </rect>
     </property>
-    <property name="text">
-     <string>PushButton</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="BOTTOM_RIGHT_DELETE_ME_2">
-    <property name="geometry">
-     <rect>
-      <x>853</x>
-      <y>723</y>
-      <width>10</width>
-      <height>10</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>PushButton</string>
-    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_14">
+       <item>
+        <widget class="QLabel" name="front_left">
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>frontLeft</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="back_left">
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>backLeft</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QLabel" name="car_label">
+       <property name="text">
+        <string>carLabel</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_13">
+       <item>
+        <widget class="QLabel" name="front_right">
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>frontRight</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="back_right">
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>50</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>backRight</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </widget>
   </widget>
   <widget class="QMenuBar" name="menubar">
@@ -733,8 +882,8 @@ background-color:  #2dcc6b;
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>863</width>
-     <height>37</height>
+     <width>1320</width>
+     <height>22</height>
     </rect>
    </property>
   </widget>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -44,7 +44,7 @@ background-color:  #2dcc6b;
     <property name="geometry">
      <rect>
       <x>160</x>
-      <y>330</y>
+      <y>440</y>
       <width>100</width>
       <height>32</height>
      </rect>
@@ -56,8 +56,8 @@ background-color:  #2dcc6b;
    <widget class="QPushButton" name="decreaseBattery">
     <property name="geometry">
      <rect>
-      <x>280</x>
-      <y>330</y>
+      <x>290</x>
+      <y>460</y>
       <width>100</width>
       <height>32</height>
      </rect>

--- a/scaler.cpp
+++ b/scaler.cpp
@@ -1,0 +1,1 @@
+#include "scaler.h"

--- a/scaler.h
+++ b/scaler.h
@@ -1,0 +1,13 @@
+#ifndef SCALER_H
+#define SCALER_H
+
+#include <QMainWindow>
+
+const int screenWidth = 863;
+const int screenHeight = 738;
+
+const int topIconWH = .06 * screenHeight;
+const int blinkerIconWH = .15 * screenWidth;
+const int driveModeIconWH = .08 * screenHeight;
+
+#endif // SCALER_H

--- a/scaler.h
+++ b/scaler.h
@@ -1,13 +1,13 @@
 #ifndef SCALER_H
 #define SCALER_H
 
-#include <QMainWindow>
+//Its double for calculations
+const double screenWidth = 863;
+const double screenHeight = 738;
 
-const int screenWidth = 863;
-const int screenHeight = 738;
+const int vOff = 5;
+const int hOff = 5;
 
-const int topIconWH = .06 * screenHeight;
-const int blinkerIconWH = .15 * screenWidth;
-const int driveModeIconWH = .08 * screenHeight;
+const int vBottomOff = 10;
 
 #endif // SCALER_H

--- a/speed.cpp
+++ b/speed.cpp
@@ -1,4 +1,5 @@
 #include "speed.h"
+#include "scaler.h"
 
 Speed::Speed() : speed(25) {}
 
@@ -6,6 +7,10 @@ void Speed::setup(Ui::MainWindow *ui) {
   this->ui = ui;
   this->speed = 25;
   this->ui->speed->display(speed);
+  int speedSize = screenWidth*.20;
+  ui->speed->resize(speedSize,speedSize);
+  ui->speed->move(screenWidth/2,screenHeight/4);
+  ui->mph->move(screenWidth/2,screenHeight/4+speedSize);
 }
 
 void Speed::increaseSpeed(int value) {

--- a/warnings.cpp
+++ b/warnings.cpp
@@ -1,11 +1,12 @@
 #include "warnings.h"
+#include "scaler.h"
 
 Warnings::Warnings(){ return; }
 
 void Warnings::setup(Ui::MainWindow *ui) {
   this->ui = ui;
-    WarningLabel* battery = new WarningLabel(OFF,QPixmap(":/icons/battery.png"),ui->batteryWarning);
-    WarningLabel* motor= new WarningLabel(OFF,QPixmap(":/icons/motor.png"),ui->motorWarning);
+    WarningLabel* battery = new WarningLabel(OFF,QPixmap(":/icons/battery.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation),ui->batteryWarning);
+    WarningLabel* motor= new WarningLabel(OFF,QPixmap(":/icons/motor.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation),ui->motorWarning);
 
     warning_labels.insert({BATTERY, battery});
     warning_labels.insert({MOTOR, motor});

--- a/warnings.cpp
+++ b/warnings.cpp
@@ -5,8 +5,12 @@ Warnings::Warnings(){ return; }
 
 void Warnings::setup(Ui::MainWindow *ui) {
   this->ui = ui;
+    int topIconWH = .07 * screenWidth;
     WarningLabel* battery = new WarningLabel(OFF,QPixmap(":/icons/battery.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation),ui->batteryWarning);
     WarningLabel* motor= new WarningLabel(OFF,QPixmap(":/icons/motor.png").scaled(topIconWH,topIconWH, Qt::KeepAspectRatio, Qt::SmoothTransformation),ui->motorWarning);
+
+    ui->batteryWarning->move(hOff,vOff);
+    ui->motorWarning->move(screenWidth/6 + hOff, vOff);
 
     warning_labels.insert({BATTERY, battery});
     warning_labels.insert({MOTOR, motor});


### PR DESCRIPTION
Added scaling to each widget, not buttons. 
Screen Width and Screen Height need to be changed according to screen size, in scaler.h.
Specific scales and positions can be found in the setup of each label.
closes #27